### PR TITLE
Allow spamprotection ~2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.3.0",
         "silverstripe/framework": "^3.1",
-        "silverstripe/spamprotection": "~1.2.0"
+        "silverstripe/spamprotection": ">=1.2.0 <3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
This change allows silverstripe/spamprotection:2.0 to be specified in a project's composer.