### PR TITLE
Configurable CSS

### DIFF
--- a/src/FormField/HoneypotField.php
+++ b/src/FormField/HoneypotField.php
@@ -116,7 +116,7 @@ class HoneypotField extends \HiddenField
      *
      * @return string
      */
-    protected function getFieldStyle()
+    public function getFieldStyle()
     {
       $default_css_rule = 'display:none!important';
       $css_rule = \Config::inst()->get(__CLASS__, 'field_style_rule');

--- a/src/FormField/HoneypotField.php
+++ b/src/FormField/HoneypotField.php
@@ -83,7 +83,7 @@ class HoneypotField extends \HiddenField
                 'id'    => $this->ID(),
                 'name'  => $this->getName(),
                 'value' => $this->Value(),
-                'style' => 'display:none!important',
+                'style' => $this->getFieldStyle(),
             )
         );
     }
@@ -104,8 +104,26 @@ class HoneypotField extends \HiddenField
                 'id'    => $this->ID() . '_Timestamp',
                 'name'  => $this->getName() . '_Timestamp',
                 'value' => time(),
-                'style' => 'display:none!important',
+                'style' => $this->getFieldStyle(),
             )
         );
+    }
+    
+    /**
+     * Return a configured style rule for the fields, if none is configured use a default display:none rule
+     *
+     * @codeCoverageIgnore
+     *
+     * @return string
+     */
+    protected function getFieldStyle()
+    {
+      $default_css_rule = 'display:none!important';
+      $css_rule = \Config::inst()->get(__CLASS__, 'field_style_rule');
+      if(!$css_rule) {
+        return $default_css_rule;
+      } else {
+        return $css_rule;
+      }
     }
 }

--- a/tests/HoneypotFieldTest.php
+++ b/tests/HoneypotFieldTest.php
@@ -43,6 +43,32 @@ class HoneypotFieldTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($valid);
     }
+    
+    public function testCustomStyleAttribute()
+    {
+        $styleRule = "position:absolute!important;left:-9000px!important;";
+        \Config::inst()->update('StudioBonito\SilverStripe\SpamProtection\Honeypot\FormField\HoneypotField', 'field_style_rule', $styleRule);
+        
+        $honeypotField = new HoneypotField('Captcha');
+        $honeypotField->setValue(null);
+        
+        $styleAttribute = $honeypotField->getFieldStyle();
+        
+        $this->assertEquals($styleRule, $styleAttribute);
+    }
+    
+    public function testDefaultStyleAttribute()
+    {
+        $defaultStyleRule = 'display:none!important';
+        \Config::inst()->remove('StudioBonito\SilverStripe\SpamProtection\Honeypot\FormField\HoneypotField', 'field_style_rule');
+        
+        $honeypotField = new HoneypotField('Captcha');
+        $honeypotField->setValue(null);
+        
+        $styleAttribute = $honeypotField->getFieldStyle();
+        
+        $this->assertEquals($defaultStyleRule, $styleAttribute);
+    }
 
     /**
      * @return m\MockInterface


### PR DESCRIPTION
This change allows configuration of an alternative style rule used to hide the fields, such as absolute positioning or a transform. Falls back to display:none!important if not configured.